### PR TITLE
Log message has incorrect launchctl example

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -182,7 +182,7 @@ EOF
   fi
   log "${success}The ${component}Tmux ${success}paste buffer launch agent is now installed"
   log "${information}To disable temporarily, run: launchctl unload $LAUNCHAGENTS_DIR/uk.co.newbamboo.hermes.plist"
-  log "${information}To disable permanently, run: launchctl -w unload $LAUNCHAGENTS_DIR/uk.co.newbamboo.hermes.plist"
+  log "${information}To disable permanently, run: launchctl unload -w $LAUNCHAGENTS_DIR/uk.co.newbamboo.hermes.plist"
 }
 
 function make_config_dir () {


### PR DESCRIPTION
Switched the arguments around so the -w flag works correctly when unloading the tmux thingy.
